### PR TITLE
API-171 - Add support for custom promos to magento

### DIFF
--- a/Api/VioletCustomDiscountRepositoryInterface.php
+++ b/Api/VioletCustomDiscountRepositoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+namespace Violet\VioletConnect\Api;
+
+/**
+ * Interface VioletCustomDiscountRepositoryInterface
+ */
+interface VioletCustomDiscountRepositoryInterface
+{
+    /**
+     * Apply custom discount to guest cart
+     * 
+     * @param string $cartId
+     * @param \Violet\VioletConnect\Model\Data\CustomDiscount $customDiscount
+     * @return bool
+     */
+    public function applyCustomDiscount($cartId, $customDiscount);
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,123 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is **Violet_VioletConnect**, a Magento 2 module that integrates Magento stores with Violet's omnichannel distribution platform. The module enables seamless product synchronization, order management, and cart operations through REST API endpoints.
+
+## Architecture
+
+### Module Structure
+- **Api/**: Interface definitions for all service contracts
+- **Model/**: Business logic, data models, and repository implementations
+- **Observer/**: Event observers for product updates, order placement, and inventory changes
+- **Controller/**: Web controllers for admin functionality
+- **Helper/**: Utility classes and helper functions
+- **Block/**: View layer components
+- **Setup/**: Database schema and data installation scripts
+- **etc/**: Configuration files (XML)
+- **view/**: Frontend templates and assets
+
+### Key Components
+
+#### Service Contracts (Api Layer)
+The module follows Magento's service contract pattern with interfaces in `Api/`:
+- `VioletRepositoryInterface`: Core product and order operations
+- `VioletGuestCartItemRepositoryInterface`: Guest cart item management
+- `VioletGuestCartRepositoryInterface`: Guest cart operations
+- `VioletOrderRepositoryInterface`: Order creation and management
+
+#### Dependency Injection (etc/di.xml)
+All API interfaces are mapped to concrete implementations in `Model/ResourceModel/` using Magento's DI system.
+
+#### Event System (etc/events.xml)
+The module listens to critical Magento events:
+- `catalog_product_save_after`: Product updates
+- `checkout_submit_all_after`: Order placement
+- `order_cancel_after`: Order cancellations
+- `catalog_product_delete_after`: Product deletions
+- `cataloginventory_stock_item_save_commit_after`: Inventory changes
+
+#### REST API Endpoints (etc/webapi.xml)
+All endpoints are prefixed with `/V1/violet/` and require admin authentication:
+- Product operations: `/V1/violet/skus/`, `/V1/violet/sku-children/:sku`
+- Cart operations: `/V1/violet/guest-carts/`, `/V1/violet/guest-carts/:cartId/items`
+- Order operations: `/V1/violet/orders`, `/V1/violet/orders/:orderId/`
+- Configuration: `/V1/violet/configuration/`
+
+#### Payment Integration (etc/config.xml, etc/payment.xml)
+Defines a custom "Violet" payment method with specific configuration for offline payment processing.
+
+### Namespace and Registration
+- **Namespace**: `Violet\VioletConnect`
+- **Module Name**: `Violet_VioletConnect`
+- **Registration**: Standard Magento 2 module registration via `registration.php`
+
+## Development Commands
+
+### Magento Commands
+Since this is a Magento 2 module, use standard Magento CLI commands:
+
+```bash
+# Module management
+bin/magento module:enable Violet_VioletConnect
+bin/magento module:disable Violet_VioletConnect
+bin/magento setup:upgrade
+bin/magento setup:di:compile
+bin/magento cache:clean
+bin/magento cache:flush
+
+# Development mode
+bin/magento deploy:mode:set developer
+bin/magento deploy:mode:set production
+
+# Static content deployment
+bin/magento setup:static-content:deploy
+```
+
+### Testing API Endpoints
+Test REST API endpoints using tools like Postman or curl:
+```bash
+# Example: Get SKU count
+curl -X GET "https://your-magento-site.com/rest/V1/violet/skus/count" \
+  -H "Authorization: Bearer YOUR_ADMIN_TOKEN"
+```
+
+## Dependencies
+
+### Magento Core Dependencies (etc/module.xml)
+- Magento_Backend
+- Magento_Sales
+- Magento_Payment  
+- Magento_Quote
+- Magento_Directory
+- Magento_Checkout
+- Magento_Config
+
+### Composer
+- Type: `magento2-module` 
+- License: OSL-3.0, AFL-3.0
+- No external PHP dependencies (empty require block)
+
+## Key Files to Understand
+
+When working with this module, these files are essential:
+- `etc/module.xml`: Module definition and dependencies
+- `etc/di.xml`: Dependency injection configuration
+- `etc/webapi.xml`: REST API endpoint definitions
+- `etc/events.xml`: Event observer configuration
+- `Api/VioletRepositoryInterface.php`: Main service contract
+- `registration.php`: Module registration with Magento
+
+## Configuration
+
+The module uses Magento's standard configuration system with XML files in the `etc/` directory. Payment method configuration is defined in `etc/config.xml` and `etc/payment.xml`.
+
+## Development Notes
+
+- Follow Magento 2 coding standards and best practices
+- All API endpoints require admin authentication
+- The module integrates with Magento's event system for real-time data synchronization
+- Use Magento's service contract pattern for all new functionality
+- Database schema changes should be handled through Setup scripts

--- a/Model/Data/CustomDiscount.php
+++ b/Model/Data/CustomDiscount.php
@@ -1,0 +1,92 @@
+<?php
+namespace Violet\VioletConnect\Model\Data;
+
+/**
+ * Class CustomDiscount
+ */
+class CustomDiscount extends \Magento\Framework\DataObject
+{
+    /**
+     * Get discount code (optional for custom discounts)
+     * 
+     * @return string|null
+     */
+    public function getCode()
+    {
+        return $this->getData('code');
+    }
+
+    /**
+     * Set discount code (optional for custom discounts)
+     * 
+     * @param string|null $code
+     * @return $this
+     */
+    public function setCode($code)
+    {
+        return $this->setData('code', $code);
+    }
+
+    /**
+     * Get discount amount total
+     * 
+     * @return float
+     */
+    public function getAmountTotal()
+    {
+        return (float) $this->getData('amount_total');
+    }
+
+    /**
+     * Set discount amount total
+     * 
+     * @param float $amountTotal
+     * @return $this
+     */
+    public function setAmountTotal($amountTotal)
+    {
+        return $this->setData('amount_total', $amountTotal);
+    }
+
+    /**
+     * Get discount type
+     * 
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->getData('type');
+    }
+
+    /**
+     * Set discount type
+     * 
+     * @param string $type
+     * @return $this
+     */
+    public function setType($type)
+    {
+        return $this->setData('type', $type);
+    }
+
+    /**
+     * Get discount status
+     * 
+     * @return string
+     */
+    public function getStatus()
+    {
+        return $this->getData('status');
+    }
+
+    /**
+     * Set discount status
+     * 
+     * @param string $status
+     * @return $this
+     */
+    public function setStatus($status)
+    {
+        return $this->setData('status', $status);
+    }
+}

--- a/Model/ResourceModel/VioletCustomDiscountRepository.php
+++ b/Model/ResourceModel/VioletCustomDiscountRepository.php
@@ -1,0 +1,139 @@
+<?php
+namespace Violet\VioletConnect\Model\ResourceModel;
+
+use Violet\VioletConnect\Api\VioletCustomDiscountRepositoryInterface;
+use Violet\VioletConnect\Model\Data\CustomDiscount;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Exception\LocalizedException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Violet VioletCustomDiscountRepository
+ */
+class VioletCustomDiscountRepository implements VioletCustomDiscountRepositoryInterface
+{
+    /**
+     * @var CartRepositoryInterface
+     */
+    private $quoteRepository;
+
+    /**
+     * @var QuoteIdMaskFactory
+     */
+    private $quoteIdMaskFactory;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param CartRepositoryInterface $quoteRepository
+     * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        CartRepositoryInterface $quoteRepository,
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        LoggerInterface $logger
+    ) {
+        $this->quoteRepository = $quoteRepository;
+        $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Apply custom discount to guest cart
+     * 
+     * @param string $cartId
+     * @param CustomDiscount $customDiscount
+     * @return bool
+     */
+    public function applyCustomDiscount($cartId, $customDiscount)
+    {
+        try {
+            $this->logger->info('Applying custom discount to cart', [
+                'cart_id' => $cartId,
+                'discount_code' => $customDiscount->getCode() ?: 'N/A',
+                'discount_amount' => $customDiscount->getAmountTotal()
+            ]);
+
+            // Load quote by masked ID
+            $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+            if (!$quoteIdMask->getQuoteId()) {
+                $this->logger->error('Quote not found for cart ID: ' . $cartId);
+                return false;
+            }
+
+            $quote = $this->quoteRepository->get($quoteIdMask->getQuoteId());
+            if (!$quote->getId()) {
+                $this->logger->error('Quote entity not found for ID: ' . $quoteIdMask->getQuoteId());
+                return false;
+            }
+
+            // Convert discount amount from cents to currency units (divide by 100)
+            $discountAmount = $customDiscount->getAmountTotal() / 100;
+            
+            // Apply negative discount amount (discount reduces total)
+            $discountAmount = -abs($discountAmount);
+
+            // Store custom discount information on quote for reference
+            $quote->setData('violet_custom_discount_code', $customDiscount->getCode() ?: 'Custom Discount');
+            $quote->setData('violet_custom_discount_amount', $discountAmount);
+
+            // Apply discount to shipping address (this is where Magento stores cart-level discounts)
+            $shippingAddress = $quote->getShippingAddress();
+            $shippingAddress->setDiscountAmount($discountAmount);
+            $shippingAddress->setBaseDiscountAmount($discountAmount);
+            
+            // Set discount description for display purposes
+            $discountDescription = $customDiscount->getCode() ? 
+                'Custom Discount: ' . $customDiscount->getCode() : 
+                'Custom Discount';
+            $shippingAddress->setDiscountDescription($discountDescription);
+
+            // For virtual products or when no shipping is needed, also apply to billing address
+            if ($quote->isVirtual() || !$quote->getShippingAddress()->getCountryId()) {
+                $billingAddress = $quote->getBillingAddress();
+                $billingAddress->setDiscountAmount($discountAmount);
+                $billingAddress->setBaseDiscountAmount($discountAmount);
+                $billingAddress->setDiscountDescription($discountDescription);
+            }
+
+            // Collect totals to recalculate with the discount
+            $quote->collectTotals();
+            
+            // Save the quote
+            $this->quoteRepository->save($quote);
+
+            $this->logger->info('Custom discount applied successfully', [
+                'cart_id' => $cartId,
+                'discount_amount' => $discountAmount,
+                'quote_grand_total' => $quote->getGrandTotal()
+            ]);
+
+            return true;
+
+        } catch (NoSuchEntityException $e) {
+            $this->logger->error('Cart not found: ' . $e->getMessage(), [
+                'cart_id' => $cartId,
+                'exception' => $e
+            ]);
+            return false;
+        } catch (LocalizedException $e) {
+            $this->logger->error('Error applying custom discount: ' . $e->getMessage(), [
+                'cart_id' => $cartId,
+                'exception' => $e
+            ]);
+            return false;
+        } catch (\Exception $e) {
+            $this->logger->error('Unexpected error applying custom discount: ' . $e->getMessage(), [
+                'cart_id' => $cartId,
+                'exception' => $e
+            ]);
+            return false;
+        }
+    }
+}

--- a/Observer/BeforeSalesOrderPlaced.php
+++ b/Observer/BeforeSalesOrderPlaced.php
@@ -76,6 +76,9 @@ class BeforeSalesOrderPlaced implements ObserverInterface
                         $order->setShippingDescription($shippingInfo->shipping_description);
                     }
                 }
+
+                // preserve custom discount information from quote to order
+                $this->preserveCustomDiscountData($quote, $order);
             }
         } catch (\Exception $e) {}
     }
@@ -124,5 +127,32 @@ class BeforeSalesOrderPlaced implements ObserverInterface
      */
     private function sumGrandTotal($orderTotals) {
         return $orderTotals->getShippingAmount() + $orderTotals->getSubtotal() + $orderTotals->getTaxAmount() + $orderTotals->getDiscountAmount();
+    }
+
+    /**
+     * Preserve custom discount data from quote to order
+     * 
+     * @param \Magento\Quote\Model\Quote $quote
+     * @param \Magento\Sales\Model\Order $order
+     * @return void
+     */
+    private function preserveCustomDiscountData($quote, $order) {
+        // Check if quote has custom discount data
+        $customDiscountCode = $quote->getData('violet_custom_discount_code');
+        $customDiscountAmount = $quote->getData('violet_custom_discount_amount');
+        
+        if ($customDiscountCode && $customDiscountAmount) {
+            // Store custom discount information on the order for reference
+            $order->setData('violet_custom_discount_code', $customDiscountCode);
+            $order->setData('violet_custom_discount_amount', $customDiscountAmount);
+            
+            // Ensure discount description is preserved on order
+            $discountDescription = ($customDiscountCode && $customDiscountCode !== 'Custom Discount') ? 
+                'Custom Discount: ' . $customDiscountCode : 
+                'Custom Discount';
+            if (!$order->getDiscountDescription()) {
+                $order->setDiscountDescription($discountDescription);
+            }
+        }
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -7,4 +7,5 @@
   <preference for="Violet\VioletConnect\Api\VioletGuestShippingInformationRepositoryInterface" type="Violet\VioletConnect\Model\ResourceModel\VioletGuestShippingInformationRepository" />
   <preference for="Violet\VioletConnect\Api\VioletGuestCartRepositoryInterface" type="Violet\VioletConnect\Model\ResourceModel\VioletGuestCartRepository" />
   <preference for="Violet\VioletConnect\Api\VioletOrderRepositoryInterface" type="Violet\VioletConnect\Model\ResourceModel\VioletOrderRepository" />
+  <preference for="Violet\VioletConnect\Api\VioletCustomDiscountRepositoryInterface" type="Violet\VioletConnect\Model\ResourceModel\VioletCustomDiscountRepository" />
 </config>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -109,4 +109,10 @@
             <resource ref="Magento_Backend::admin"/>
         </resources>
     </route>
+    <route url="/V1/violet/orders/:cartId/custom-discount" method="PUT">
+        <service class="Violet\VioletConnect\Api\VioletCustomDiscountRepositoryInterface" method="applyCustomDiscount"/>
+        <resources>
+            <resource ref="Magento_Backend::admin"/>
+        </resources>
+    </route>
 </routes>


### PR DESCRIPTION
### TL;DR

Added custom discount functionality to the Violet Connect module, allowing application of custom discounts to guest carts.

### What changed?

- Created a new API interface `VioletCustomDiscountRepositoryInterface` with a method to apply custom discounts to guest carts
- Implemented a `CustomDiscount` data model to handle discount properties (code, amount, type, status)
- Added the `VioletCustomDiscountRepository` implementation that applies discounts to guest carts
- Updated the `BeforeSalesOrderPlaced` observer to preserve custom discount data when converting quotes to orders
- Registered the new interface in `di.xml` with its implementation
- Added a new API endpoint in `webapi.xml` for applying custom discounts to orders
