### PR TITLE
Restrict Violet payment method availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## 1.4.1
+
+### Security
+
+- Restricted the `violet` payment method from being available for internal use. It was discovered that the core `can_use_checkout` flag may not work as expected in some Magento instances. When this occurred, the payment method could appear in the Guest Carts API payment method listings (e.g. the `shipping-information` endpoint response) and be used to place orders outside of Violet's API flow. The method is now only usable programmatically through Violet's custom API endpoints.
+
+### Changed
+
+- Added `isAvailable()` override to `Violet` payment model to return `false`, preventing the method from appearing in any payment method listing.
+- Added `can_use_internal=0` to payment configuration to explicitly block usage in the Magento admin panel.
+
+## 1.4.0
+
+- Direct order submission support.
+
+## 1.0.0
+
+- Initial release.

--- a/Model/Violet.php
+++ b/Model/Violet.php
@@ -24,4 +24,17 @@ class Violet extends \Magento\Payment\Model\Method\AbstractMethod
      * @var bool
      */
     protected $_isOffline = true;
+
+    /**
+     * This payment method is not available for selection in any checkout or admin context.
+     * It is only used programmatically by Violet's own API endpoints, which set the payment
+     * method directly on the quote object, bypassing this availability check.
+     *
+     * @param \Magento\Quote\Api\Data\CartInterface|null $quote
+     * @return bool
+     */
+    public function isAvailable(\Magento\Quote\Api\Data\CartInterface $quote = null)
+    {
+        return false;
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "marketplace"
     ],
     "type": "magento2-module",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -10,6 +10,7 @@
                 <instructions>Instruction.</instructions>
                 <payment_action>true</payment_action>
                 <can_use_checkout>0</can_use_checkout>
+                <can_use_internal>0</can_use_internal>
                 <model>Violet\VioletConnect\Model\Violet</model>
                 <group>offline</group>
             </violet>


### PR DESCRIPTION
This restricts the violet payment method so it is not exposed in Magento checkout or admin payment method listings. It adds can_use_internal=0, overrides Violet::isAvailable() to return false, and bumps the module version to 1.4.1. It also adds a changelog documenting the security rationale and release notes for 1.4.1.