### PR TITLE
Fix guest billing address validation and set customer email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.3
+
+- Fixed guest billing address assignment to use `validateForCart` and persist the customer email on the quote.
+
 ## 1.4.2
 
 - Made the `isAvailable()` override on the `Violet` payment model context-aware.

--- a/Model/ResourceModel/VioletGuestBillingAddressRepository.php
+++ b/Model/ResourceModel/VioletGuestBillingAddressRepository.php
@@ -44,7 +44,7 @@ class VioletGuestBillingAddressRepository implements VioletGuestBillingAddressRe
         \Magento\Quote\Api\CartRepositoryInterface $quoteRepository,
         \Magento\Quote\Model\QuoteIdMaskFactory $quoteIdMaskFactory,
         \Magento\Quote\Api\BillingAddressManagementInterface $billingAddressManagement,
-        \Magento\Quote\Model\QuoteAddressValidator $addressValidator,
+        \Magento\Quote\Model\QuoteAddressValidator $addressValidator
     ) {
         $this->quoteRepository = $quoteRepository;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
@@ -78,10 +78,11 @@ class VioletGuestBillingAddressRepository implements VioletGuestBillingAddressRe
         $items = $quote->getItems();
 
          // validate the address
-         $this->addressValidator->validateWithExistingAddress($quote, $address);
+         $this->addressValidator->validateForCart($quote, $address);
 
-        // apply billing address to quote
+        // apply billing address and customer email to quote
         $quote->setBillingAddress($address);
+        $quote->setCustomerEmail($address->getEmail());
 
         // if requested apply billing address as shipping address
         if ($useForShipping) {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "marketplace"
     ],
     "type": "magento2-module",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "license": [
         "OSL-3.0",
         "AFL-3.0"


### PR DESCRIPTION
## Summary
- Switch guest billing address validation from `validateWithExistingAddress` to `validateForCart`, which is the correct validator for carts that do not yet have a persisted billing address.
- Persist the customer email from the submitted billing address onto the quote so guest checkouts retain the email.
- Remove a stray trailing comma in the constructor signature for PHP compatibility.

## Test plan
- [ ] Assign a billing address to a guest cart via the Violet endpoint and confirm the address and email are saved on the quote.