### PR TITLE
Fix Violet billing country fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.5
+
+- `VioletGuestCartRepository::placeOrder` now repairs an existing quote billing address with the shipping country when billing has no country, while still leaving the order-level fallback to create a billing address from shipping data if the billing row is missing entirely.
+- The shipping → billing fallback now logs an info message in both layers (quote-level in `placeOrder`, order-level in `BeforeSalesOrderPlaced`) so production telemetry shows when the fallback is engaged.
+
 ## 1.4.4
 
 - The `BeforeSalesOrderPlaced` observer now copies the order's shipping address to the billing address when billing is missing or has no country, preventing `AbstractMethod::validate()` from raising a 500 during payment validation on Violet-sourced orders.

--- a/Model/Data/VioletConfiguration.php
+++ b/Model/Data/VioletConfiguration.php
@@ -119,6 +119,6 @@ class VioletConfiguration
     */
     public function getPluginVersion()
     {
-        return "1.4.4";
+        return "1.4.5";
     }
 }

--- a/Model/ResourceModel/VioletGuestCartRepository.php
+++ b/Model/ResourceModel/VioletGuestCartRepository.php
@@ -2,9 +2,12 @@
 namespace Violet\VioletConnect\Model\ResourceModel;
 
 use Violet\VioletConnect\Api\VioletGuestCartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Address;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Registry;
+use Psr\Log\LoggerInterface;
 use Violet\VioletConnect\Model\Violet;
 
 /**
@@ -33,23 +36,31 @@ class VioletGuestCartRepository implements VioletGuestCartRepositoryInterface
      */
     private $registry;
 
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
 
     /**
      * @param CartRepositoryInterface $quoteRepository
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
      * @param QuoteManagement $quoteManagement
      * @param Registry $registry
+     * @param LoggerInterface $logger
      */
     public function __construct(
         \Magento\Quote\Api\CartRepositoryInterface $quoteRepository,
         \Magento\Quote\Model\QuoteIdMaskFactory $quoteIdMaskFactory,
         \Magento\Quote\Model\QuoteManagement $quoteManagement,
-        \Magento\Framework\Registry $registry
+        \Magento\Framework\Registry $registry,
+        LoggerInterface $logger
     ) {
         $this->quoteRepository = $quoteRepository;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->quoteManagement = $quoteManagement;
         $this->registry = $registry;
+        $this->logger = $logger;
     }
 
     /**
@@ -77,12 +88,59 @@ class VioletGuestCartRepository implements VioletGuestCartRepositoryInterface
             // any usage of this endpoint must use the violet payment method
             $quote->setPaymentMethod('violet'); //payment method
             $quote->getPayment()->importData(['method' => 'violet']);
+
+            // Defensive: if the quote's billing address is missing or has no country,
+            // copy from the shipping address before submitting. This prevents the order
+            // from ever being constructed without a billing country, which is the
+            // failure mode behind AbstractMethod::validate() raising on null.
+            $this->ensureQuoteBillingAddress($quote);
+
             $quote->save();
 
             return $this->quoteManagement->placeOrder($quoteIdMask->getQuoteId(), $paymentMethod);
         } finally {
             $this->registry->unregister(Violet::VIOLET_API_CONTEXT_FLAG);
         }
+    }
+
+    /**
+     * Repair an existing billing address that is missing a country by copying
+     * only the shipping country. If the billing address row is missing entirely,
+     * the order-level fallback will handle creating one from shipping data.
+     *
+     * @param Quote $quote
+     * @return void
+     */
+    private function ensureQuoteBillingAddress(Quote $quote)
+    {
+        if ($quote->getIsVirtual()) {
+            return;
+        }
+
+        $shipping = $quote->getShippingAddress();
+        if (!$shipping || !$shipping->getCountryId()) {
+            return;
+        }
+
+        $billing = $quote->getBillingAddress();
+        // If there is no billing address row at all we can't safely populate one
+        // here without an address factory. The order-level fallback in
+        // BeforeSalesOrderPlaced::ensureBillingAddress will catch that case.
+        if (!$billing || $billing->getCountryId()) {
+            return;
+        }
+
+        $billing->setCountryId($shipping->getCountryId());
+        $billing->setAddressType(Address::TYPE_BILLING);
+
+        if (!$quote->getCustomerEmail() && $shipping->getEmail()) {
+            $quote->setCustomerEmail($shipping->getEmail());
+        }
+
+        $this->logger->info(
+            'Violet placeOrder: copied shipping country to quote billing address (quoteId='
+            . $quote->getId() . ')'
+        );
     }
 
     /**

--- a/Observer/BeforeSalesOrderPlaced.php
+++ b/Observer/BeforeSalesOrderPlaced.php
@@ -7,6 +7,7 @@ use Magento\Sales\Api\Data\OrderAddressInterfaceFactory;
 use Magento\Sales\Model\Order;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Model\QuoteRepository;
+use Psr\Log\LoggerInterface;
 
 /**
  * Violet Before Order Placed
@@ -26,12 +27,19 @@ class BeforeSalesOrderPlaced implements ObserverInterface
      */
     private $orderAddressFactory;
 
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
     public function __construct(
       \Magento\Quote\Api\CartRepositoryInterface $quoteRepository,
-      \Magento\Sales\Api\Data\OrderAddressInterfaceFactory $orderAddressFactory
+      \Magento\Sales\Api\Data\OrderAddressInterfaceFactory $orderAddressFactory,
+      LoggerInterface $logger
     ) {
             $this->quoteRepository = $quoteRepository;
             $this->orderAddressFactory = $orderAddressFactory;
+            $this->logger = $logger;
     }
 
     public function execute(\Magento\Framework\Event\Observer $observer)
@@ -95,10 +103,10 @@ class BeforeSalesOrderPlaced implements ObserverInterface
     }
 
     /**
-     * Ensure the order has a usable billing address. If it doesn't, copy
-     * from the order's shipping address. Mirrors Magento's "billing same
-     * as shipping" default and prevents AbstractMethod::validate() from
-     * calling getCountryId() on a null billing address.
+     * Ensure the order has a usable billing address. If the address row is
+     * missing, copy shipping data; if the row exists but has no country, copy
+     * only the shipping country. This prevents AbstractMethod::validate()
+     * from reading a null billing country.
      *
      * @param Order $order
      * @return void
@@ -118,16 +126,26 @@ class BeforeSalesOrderPlaced implements ObserverInterface
             return;
         }
 
-        $shippingData = $shipping->getData();
-        unset($shippingData['entity_id'], $shippingData['parent_id'], $shippingData['address_type']);
-
         if ($billing === null) {
+            $shippingData = $shipping->getData();
+            unset($shippingData['entity_id'], $shippingData['parent_id'], $shippingData['address_type']);
+
             $newBilling = $this->orderAddressFactory->create();
             $newBilling->addData($shippingData);
             $order->setBillingAddress($newBilling);
+
+            $this->logger->info(
+                'Violet sales_order_place_before: copied shipping address to order billing address (quoteId='
+                . $order->getQuoteId() . ')'
+            );
         } else {
-            $billing->addData($shippingData);
+            $billing->setCountryId($shipping->getCountryId());
             $billing->setAddressType(OrderAddressInterface::ADDRESS_TYPE_BILLING);
+
+            $this->logger->info(
+                'Violet sales_order_place_before: copied shipping country to order billing address (quoteId='
+                . $order->getQuoteId() . ')'
+            );
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "marketplace"
     ],
     "type": "magento2-module",
-    "version": "1.4.4",
+    "version": "1.4.5",
     "license": [
         "OSL-3.0",
         "AFL-3.0"


### PR DESCRIPTION
## Summary
- Modify Violet guest checkout so an existing billing address with a missing country only inherits the shipping country before place order, instead of being overwritten with the full shipping address.
- Keep the order-level fallback for truly missing billing rows and add info logging for both quote-level and order-level fallback paths.
- Bump the module version to 1.4.5 and document the behavior change in the changelog.
